### PR TITLE
Disable scheduled 'Microsoft Compatibility Appraiser' task

### DIFF
--- a/Unfuck-Windows10.ps1
+++ b/Unfuck-Windows10.ps1
@@ -400,6 +400,7 @@ function Protect-Privacy {
         "UsbCeip"
         "DmClient"
         "DmClientOnScenarioDownload"
+        "Microsoft Compatibility Appraiser"
     )
     foreach ($Task in $SchedTasks) {
         


### PR DESCRIPTION
Unnecessary telemetry service that takes huge amounts of CPU usage from time to time, especially on systems without internet connection.